### PR TITLE
Flatpak manifest: Update to 3.38.6 upstream release

### DIFF
--- a/org.gnome.epiphany.yml
+++ b/org.gnome.epiphany.yml
@@ -38,7 +38,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/epiphany.git
-        tag: '3.38.3'
+        tag: '3.38.6'
+        commit: 73615c0fc1f76842aa7ee98614c10de398b809ae
         disable-shallow-clone: true
       - type: patch
         path: dark-style.patch


### PR DESCRIPTION
Not quite #30, but they did make a new 3.38.6 release a few days ago—and there are a number of fixes in the interim releases as well.

Not sure if I need to update the patches here but they applied correctly when building locally.