### PR TITLE
Update webkit to 2.34

### DIFF
--- a/org.gnome.epiphany.yml
+++ b/org.gnome.epiphany.yml
@@ -4,7 +4,7 @@ runtime-version: '6'
 sdk: io.elementary.Sdk
 command: epiphany
 finish-args:
-  - '--device=dri'
+  - '--device=all'
   - '--filesystem=/run/.heim_org.h5l.kcm-socket'
   - '--filesystem=xdg-download'
   - '--share=ipc'
@@ -43,6 +43,8 @@ modules:
       - type: archive
         url: https://webkitgtk.org/releases/webkitgtk-2.34.0.tar.xz
         sha256: 880c8ee626f67019f67557ca09e59a23ecf245e60f6173215f1a8823cb09af34
+      - type: patch # Remove once https://bugs.webkit.org/show_bug.cgi?id=228664 is merged and available
+        path: webkit-emoji-picker.patch
     modules:
       - name: evdev
         buildsystem: meson

--- a/org.gnome.epiphany.yml
+++ b/org.gnome.epiphany.yml
@@ -33,6 +33,42 @@ modules:
         url: https://github.com/flatpak/libportal.git
         tag: '0.4'
 
+  - name: webkit
+    buildsystem: cmake
+    config-opts:
+    - '-DPORT=GTK'
+    - '-DENABLE_BUBBLEWRAP_SANDBOX=ON'
+    - '-DUSE_SOUP2=ON' # Once GNOME Web 41 is available, turn this off and include libsoup3 as a dependency
+    sources:
+      - type: archive
+        url: https://webkitgtk.org/releases/webkitgtk-2.34.0.tar.xz
+        sha256: 880c8ee626f67019f67557ca09e59a23ecf245e60f6173215f1a8823cb09af34
+    modules:
+      - name: evdev
+        buildsystem: meson
+        config-opts:
+        - '-Dtests=disabled'
+        sources:
+          - type: git
+            url: https://gitlab.freedesktop.org/libevdev/libevdev.git
+            tag: 'libevdev-1.11.0'
+      - name: manette
+        buildsystem: meson
+        sources:
+          - type: git
+            url: https://gitlab.gnome.org/GNOME/libmanette.git
+            commit: '0.2.6'
+      - name: bubblewrap
+        sources:
+          - type: git
+            url: https://github.com/containers/bubblewrap.git
+            tag: 'v0.5.0'
+      - name: xdg-dbus-proxy
+        sources:
+          - type: git
+            url: https://github.com/flatpak/xdg-dbus-proxy.git
+            tag: '0.1.2'
+
   - name: epiphany
     buildsystem: meson
     sources:

--- a/webkit-emoji-picker.patch
+++ b/webkit-emoji-picker.patch
@@ -1,0 +1,409 @@
+Subversion Revision: 281067
+diff --git a/Source/WebKit/PlatformGTK.cmake b/Source/WebKit/PlatformGTK.cmake
+index 48ab7c3a3523a2be6077664ef65e6ec30f14691e..7d3917b386a61242ec81b05cbb9a2da61ab2f60d 100644
+--- a/Source/WebKit/PlatformGTK.cmake
++++ b/Source/WebKit/PlatformGTK.cmake
+@@ -38,6 +38,8 @@ add_definitions(-DLOCALEDIR="${CMAKE_INSTALL_FULL_LOCALEDIR}")
+ add_definitions(-DDATADIR="${CMAKE_INSTALL_FULL_DATADIR}")
+ add_definitions(-DLIBDIR="${LIB_INSTALL_DIR}")
+ 
++WEBKIT_ADD_TARGET_PROPERTIES(WebKit COMPILE_DEFINITIONS GTK_PREFIX=\"${GTK_PREFIX}\")
++
+ if (NOT DEVELOPER_MODE AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
+     WEBKIT_ADD_TARGET_PROPERTIES(WebKit LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/webkitglib-symbols.map")
+ endif ()
+diff --git a/Source/WebKit/UIProcess/API/gtk/WebKitEmojiChooser.cpp b/Source/WebKit/UIProcess/API/gtk/WebKitEmojiChooser.cpp
+index cbca0f1266afafdd01aafad3f39d733f106f3128..268709e98b264b42acc9229258811363ebc3d6a5 100644
+--- a/Source/WebKit/UIProcess/API/gtk/WebKitEmojiChooser.cpp
++++ b/Source/WebKit/UIProcess/API/gtk/WebKitEmojiChooser.cpp
+@@ -48,6 +48,7 @@ struct EmojiSection {
+     GtkWidget* button { nullptr };
+     bool isEmpty { false };
+     const char* firstEmojiName { nullptr };
++    int group { -1 };
+ };
+ 
+ using SectionList = Vector<EmojiSection, 9>;
+@@ -84,6 +85,101 @@ struct _WebKitEmojiChooserPrivate {
+ 
+ static guint signals[LAST_SIGNAL] = { 0, };
+ 
++struct EmojiData {
++    virtual GRefPtr<GVariant> getData() const = 0;
++    virtual bool isPartOfSection(const GRefPtr<GVariant>& item, const EmojiSection& section) const = 0;
++
++    static GRefPtr<GVariant> getRecent(GObject* object) {
++        GRefPtr<GVariant> emojiData = static_cast<GVariant*>(g_object_get_data(object, "emoji-data"));
++        ASSERT(emojiData);
++
++        if (g_variant_is_of_type(emojiData.get(), G_VARIANT_TYPE("(auss)")))
++            return emojiData;
++
++        GUniqueOutPtr<GVariantIter> codesIter;
++        GUniqueOutPtr<GVariantIter> keywordsIter;
++        const char* name;
++        unsigned group;
++        g_variant_get(emojiData.get(), "(au&sasu)", &codesIter.outPtr(), &name, &keywordsIter.outPtr(), &group);
++
++        GVariantBuilder codesBuilder;
++        g_variant_builder_init(&codesBuilder, G_VARIANT_TYPE("au"));
++
++        unsigned code;
++        while (g_variant_iter_loop(codesIter.get(), "u", &code))
++            g_variant_builder_add(&codesBuilder, "u", code);
++
++        return adoptGRef(g_variant_new("(auss)", &codesBuilder, name, ""));
++    }
++};
++
++struct OldEmojiData : EmojiData {
++    GRefPtr<GVariant> getData() const override {
++        GRefPtr<GBytes> bytes = adoptGRef(g_resources_lookup_data("/org/gtk/libgtk/emoji/emoji.data", G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
++        RELEASE_ASSERT_WITH_MESSAGE(bytes.get(), "Could not get old style GTK emoji data");
++        return g_variant_new_from_bytes(G_VARIANT_TYPE("a(auss)"), bytes.get(), TRUE);
++    }
++
++    bool isPartOfSection(const GRefPtr<GVariant>& item, const EmojiSection& section) const override {
++        const char* name;
++        g_variant_get_child(item.get(), 1, "&s", &name);
++        return !g_strcmp0(name, section.firstEmojiName);
++    }
++};
++
++struct NewEmojiData : EmojiData {
++    GRefPtr<GVariant> getData() const override {
++        GRefPtr<GBytes> bytes(getDataAsBytes());
++        RELEASE_ASSERT_WITH_MESSAGE(bytes.get(), "Could not get new style GTK emoji data");
++        return g_variant_new_from_bytes(G_VARIANT_TYPE("a(ausasu)"), bytes.get(), TRUE);
++    }
++
++    bool isPartOfSection(const GRefPtr<GVariant>& item, const EmojiSection& section) const override {
++        unsigned group;
++        g_variant_get_child(item.get(), 3, "u", &group);
++        return (section.group >= 0) && (section.group == static_cast<int>(group));
++    }
++
++private:
++    static GRefPtr<GBytes> getDataAsBytes() {
++        String language(pango_language_to_string(gtk_get_default_language()));
++        const auto dashPosition = language.find('-');
++        if (dashPosition != notFound)
++            language.truncate(dashPosition);
++
++        GUniquePtr<char> resourcePath(g_strconcat("/org/gtk/libgtk/emoji/", language.utf8().data(), ".data", nullptr));
++
++        GUniqueOutPtr<GError> error;
++        GRefPtr<GBytes> emojiData = adoptGRef(g_resources_lookup_data(resourcePath.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, &error.outPtr()));
++        if (emojiData) {
++            g_debug("Found emoji data for %s in resource %s", language.utf8().data(), resourcePath.get());
++            return emojiData;
++        }
++
++        if (g_error_matches(error.get(), G_RESOURCE_ERROR, G_RESOURCE_ERROR_NOT_FOUND)) {
++            String filename = language + ".gresource";
++            GUniquePtr<char> filePath(g_build_filename(GTK_PREFIX, "share", "gtk-3.0", "emoji", filename.utf8().data(), nullptr));
++            GUniquePtr<GMappedFile> file(g_mapped_file_new(filePath.get(), FALSE, nullptr));
++            if (file) {
++                GRefPtr<GBytes> data = adoptGRef(g_mapped_file_get_bytes(file.get()));
++                GRefPtr<GResource> resource = adoptGRef(g_resource_new_from_data(data.get(), nullptr));
++                g_debug("Registering resource for emoji data for %s from file %s", language.utf8().data(), filePath.get());
++                g_resources_register(resource.get());
++                if ((emojiData = adoptGRef(g_resources_lookup_data(resourcePath.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr)))) {
++                    g_debug("Found emoji data for %s in resource %s", language.utf8().data(), resourcePath.get());
++                    return emojiData;
++                }
++            }
++        }
++
++        return adoptGRef(g_resources_lookup_data("/org/gtk/libgtk/emoji/en.data", G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
++    }
++};
++
++static const EmojiData* sEmojiData = nullptr;
++static const OldEmojiData sOldEmojiData = {};
++static const NewEmojiData sNewEmojiData = {};
++
+ WEBKIT_DEFINE_TYPE(WebKitEmojiChooser, webkit_emoji_chooser, GTK_TYPE_POPOVER)
+ 
+ static void emojiPopupMenu(GtkWidget*, WebKitEmojiChooser*);
+@@ -166,9 +262,9 @@ static void webkitEmojiChooserAddRecentItem(WebKitEmojiChooser* chooser, GVarian
+     GUniquePtr<GList> children(gtk_container_get_children(GTK_CONTAINER(section.box)));
+     unsigned i = 1;
+     for (auto* l = children.get(); l; l = g_list_next(l), ++i) {
+-        auto* item2 = static_cast<GVariant*>(g_object_get_data(G_OBJECT(l->data), "emoji-data"));
++        auto item2 = EmojiData::getRecent(G_OBJECT(l->data));
+         auto modifier2 = static_cast<gunichar>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(l->data), "modifier")));
+-        if (modifier == modifier2 && g_variant_equal(item, item2)) {
++        if (modifier == modifier2 && g_variant_equal(item, item2.get())) {
+             gtk_widget_destroy(GTK_WIDGET(l->data));
+             --i;
+             continue;
+@@ -179,7 +275,7 @@ static void webkitEmojiChooserAddRecentItem(WebKitEmojiChooser* chooser, GVarian
+             continue;
+         }
+ 
+-        g_variant_builder_add(&builder, "(@(auss)u)", item2, modifier2);
++        g_variant_builder_add(&builder, "(@(auss)u)", item2.get(), modifier2);
+     }
+ 
+     auto* child = webkitEmojiChooserAddEmoji(chooser, GTK_FLOW_BOX(section.box), item, true, modifier);
+@@ -192,16 +288,35 @@ static void webkitEmojiChooserAddRecentItem(WebKitEmojiChooser* chooser, GVarian
+     g_settings_set_value(chooser->priv->settings.get(), "recent-emoji", g_variant_builder_end(&builder));
+ }
+ 
++static bool shouldClose(WebKitEmojiChooser* chooser)
++{
++    auto* display = gtk_widget_get_display(GTK_WIDGET(chooser));
++    auto* seat = gdk_display_get_default_seat(display);
++    auto* device = gdk_seat_get_pointer(seat);
++    if (!device)
++        return true;
++
++    GdkModifierType state;
++    gdk_device_get_state(device, gtk_widget_get_window(GTK_WIDGET(chooser)), nullptr, &state);
++    return (state & GDK_CONTROL_MASK) == 0;
++}
++
+ static void emojiActivated(GtkFlowBox* box, GtkFlowBoxChild* child, WebKitEmojiChooser* chooser)
+ {
+-    gtk_popover_popdown(GTK_POPOVER(chooser));
++    if (shouldClose(chooser))
++        gtk_popover_popdown(GTK_POPOVER(chooser));
++    else {
++        auto* popover = gtk_widget_get_ancestor(GTK_WIDGET(box), GTK_TYPE_POPOVER);
++        if (popover != GTK_WIDGET(chooser))
++            gtk_popover_popdown(GTK_POPOVER(popover));
++    }
+ 
+     GtkWidget* label = gtk_bin_get_child(GTK_BIN(gtk_bin_get_child(GTK_BIN(child))));
+     GUniquePtr<char> text(g_strdup(gtk_label_get_label(GTK_LABEL(label))));
+ 
+-    auto* item = static_cast<GVariant*>(g_object_get_data(G_OBJECT(child), "emoji-data"));
++    auto item = EmojiData::getRecent(G_OBJECT(child));
+     auto modifier = static_cast<gunichar>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(child), "modifier")));
+-    webkitEmojiChooserAddRecentItem(chooser, item, modifier);
++    webkitEmojiChooserAddRecentItem(chooser, item.get(), modifier);
+     g_signal_emit(chooser, signals[EMOJI_PICKED], 0, text.get());
+ }
+ 
+@@ -222,11 +337,11 @@ static void webkitEmojiChooserShowVariations(WebKitEmojiChooser* chooser, GtkWid
+     if (!child)
+         return;
+ 
+-    auto* emojiData = static_cast<GVariant*>(g_object_get_data(G_OBJECT(child), "emoji-data"));
++    auto emojiData = EmojiData::getRecent(G_OBJECT(child));
+     if (!emojiData)
+         return;
+ 
+-    if (!emojiDataHasVariations(emojiData))
++    if (!emojiDataHasVariations(emojiData.get()))
+         return;
+ 
+     GtkWidget* popover = gtk_popover_new(child);
+@@ -244,9 +359,9 @@ static void webkitEmojiChooserShowVariations(WebKitEmojiChooser* chooser, GtkWid
+     gtk_container_add(GTK_CONTAINER(popover), view);
+     gtk_widget_show(view);
+ 
+-    webkitEmojiChooserAddEmoji(chooser, GTK_FLOW_BOX(box), emojiData);
++    webkitEmojiChooserAddEmoji(chooser, GTK_FLOW_BOX(box), emojiData.get());
+     for (gunichar modifier = 0x1F3FB; modifier <= 0x1F3FF; ++modifier)
+-        webkitEmojiChooserAddEmoji(chooser, GTK_FLOW_BOX(box), emojiData, false, modifier);
++        webkitEmojiChooserAddEmoji(chooser, GTK_FLOW_BOX(box), emojiData.get(), false, modifier);
+ 
+     gtk_popover_popup(GTK_POPOVER(popover));
+ }
+@@ -272,6 +387,9 @@ static void verticalAdjustmentChanged(GtkAdjustment* adjustment, WebKitEmojiChoo
+     double value = gtk_adjustment_get_value(adjustment);
+     EmojiSection* sectionToSelect = nullptr;
+     for (auto& section : chooser->priv->sections) {
++        if (!gtk_widget_get_visible(section.box))
++            continue;
++
+         GtkAllocation allocation;
+         if (section.heading)
+             gtk_widget_get_allocation(section.heading, &allocation);
+@@ -295,10 +413,11 @@ static void verticalAdjustmentChanged(GtkAdjustment* adjustment, WebKitEmojiChoo
+     }
+ }
+ 
+-static GtkWidget* webkitEmojiChooserSetupSectionBox(WebKitEmojiChooser* chooser, GtkBox* parent, const char* firstEmojiName, const char* title, GtkAdjustment* adjustment, gboolean canHaveVariations = FALSE)
++static GtkWidget* webkitEmojiChooserSetupSectionBox(WebKitEmojiChooser* chooser, GtkBox* parent, const char* firstEmojiName, int group, const char* title, GtkAdjustment* adjustment, gboolean canHaveVariations = FALSE)
+ {
+     EmojiSection section;
+     section.firstEmojiName = firstEmojiName;
++    section.group = group;
+     if (title) {
+         GtkWidget* label = gtk_label_new(title);
+         section.heading = label;
+@@ -356,7 +475,7 @@ static void webkitEmojiChooserSetupSectionButton(WebKitEmojiChooser* chooser, Gt
+ 
+ static void webkitEmojiChooserSetupRecent(WebKitEmojiChooser* chooser, GtkBox* emojiBox, GtkBox* buttonBox, GtkAdjustment* adjustment)
+ {
+-    GtkWidget* flowBox = webkitEmojiChooserSetupSectionBox(chooser, emojiBox, nullptr, nullptr, adjustment, true);
++    GtkWidget* flowBox = webkitEmojiChooserSetupSectionBox(chooser, emojiBox, nullptr, -1, nullptr, adjustment, true);
+     webkitEmojiChooserSetupSectionButton(chooser, buttonBox, "emoji-recent-symbolic", _("Recent"));
+ 
+     bool isEmpty = true;
+@@ -448,20 +567,42 @@ static void webkitEmojiChooserSetupFilters(WebKitEmojiChooser* chooser)
+                 return TRUE;
+             }
+ 
+-            auto* emojiData = static_cast<GVariant*>(g_object_get_data(G_OBJECT(child), "emoji-data"));
++            auto emojiData = EmojiData::getRecent(G_OBJECT(child));
+             if (!emojiData) {
+                 section.isEmpty = false;
+                 return TRUE;
+             }
+ 
+             const char* name;
+-            g_variant_get_child(emojiData, 1, "&s", &name);
+-            if (g_str_match_string(text, name, TRUE)) {
+-                section.isEmpty = false;
+-                return TRUE;
++            g_variant_get_child(emojiData.get(), 1, "&s", &name);
++            GUniquePtr<char*> nameTokens(g_str_tokenize_and_fold(name, "en", nullptr));
++            GUniquePtr<char*> termTokens(g_str_tokenize_and_fold(text, "en", nullptr));
++
++            auto matchTokens = [tt = termTokens.get()](const char* const* hitTokens) -> bool {
++                bool matched = true;
++                for (unsigned i = 0; tt[i]; ++i) {
++                    for (unsigned j = 0; hitTokens[j]; ++j)
++                        if (g_str_has_prefix(hitTokens[j], tt[i]))
++                            goto oneMatched;
++
++                    matched = false;
++                    break;
++
++                oneMatched:
++                    continue;
++                }
++                return matched;
++            };
++
++            bool result = matchTokens(termTokens.get());
++            if (g_variant_is_of_type(emojiData.get(), G_VARIANT_TYPE("(ausasu)"))) {
++                const char* const* keywords;
++                g_variant_get_child(emojiData.get(), 2, "^a&s", &keywords);
++                result = result || matchTokens(keywords);
+             }
+ 
+-            return FALSE;
++            section.isEmpty = !result;
++            return result ? TRUE : FALSE;
+         }, GUINT_TO_POINTER(i), nullptr);
+     }
+ }
+@@ -470,43 +611,40 @@ static void webkitEmojiChooserSetupEmojiSections(WebKitEmojiChooser* chooser, Gt
+ {
+     static const struct {
+         const char* firstEmojiName;
++        int group;
+         const char* title;
+         const char* iconName;
+         bool canHaveVariations;
+     } sections[] = {
+-        { "grinning face", N_("Smileys & People"), "emoji-people-symbolic", true },
+-        { "selfie", N_("Body & Clothing"), "emoji-body-symbolic", true },
+-        { "monkey", N_("Animals & Nature"), "emoji-nature-symbolic", false },
+-        { "grapes", N_("Food & Drink"), "emoji-food-symbolic", false },
+-        { "globe showing Europe-Africa", N_("Travel & Places"), "emoji-travel-symbolic", false },
+-        { "jack-o-lantern", N_("Activities"), "emoji-activities-symbolic", false },
+-        { "muted speaker", _("Objects"), "emoji-objects-symbolic", false },
+-        { "ATM sign", N_("Symbols"), "emoji-symbols-symbolic", false },
+-        { "chequered flag", _("Flags"), "emoji-flags-symbolic", false }
++        { "grinning face", 0, N_("Smileys & People"), "emoji-people-symbolic", true },
++        { "selfie", 1, N_("Body & Clothing"), "emoji-body-symbolic", true },
++        { "monkey", 3, N_("Animals & Nature"), "emoji-nature-symbolic", false },
++        { "grapes", 4, N_("Food & Drink"), "emoji-food-symbolic", false },
++        { "globe showing Europe-Africa", 5, N_("Travel & Places"), "emoji-travel-symbolic", false },
++        { "jack-o-lantern", 6, N_("Activities"), "emoji-activities-symbolic", false },
++        { "muted speaker", 7, _("Objects"), "emoji-objects-symbolic", false },
++        { "ATM sign", 8, N_("Symbols"), "emoji-symbols-symbolic", false },
++        { "chequered flag", 9, _("Flags"), "emoji-flags-symbolic", false }
+     };
+ 
+     auto* vAdjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(chooser->priv->swindow));
+ 
+     GtkWidget* flowBox = nullptr;
+     for (unsigned i = 0; i < G_N_ELEMENTS(sections); ++i) {
+-        auto* box = webkitEmojiChooserSetupSectionBox(chooser, emojiBox, sections[i].firstEmojiName, sections[i].title, vAdjustment, sections[i].canHaveVariations);
++        auto* box = webkitEmojiChooserSetupSectionBox(chooser, emojiBox, sections[i].firstEmojiName, sections[i].group, sections[i].title, vAdjustment, sections[i].canHaveVariations);
+         webkitEmojiChooserSetupSectionButton(chooser, buttonBox, sections[i].iconName, sections[i].title);
+         if (!i)
+             flowBox = box;
+     }
+ 
+-    GRefPtr<GBytes> bytes = adoptGRef(g_resources_lookup_data("/org/gtk/libgtk/emoji/emoji.data", G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+-    GRefPtr<GVariant> data = g_variant_new_from_bytes(G_VARIANT_TYPE("a(auss)"), bytes.get(), TRUE);
++    GRefPtr<GVariant> data(sEmojiData->getData());
+     GUniquePtr<GVariantIter> iter(g_variant_iter_new(data.get()));
+ 
+     Function<void()> populateSections = [chooser, iter = WTFMove(iter), flowBox]() mutable {
+         auto start = MonotonicTime::now();
+         while (GRefPtr<GVariant> item = adoptGRef(g_variant_iter_next_value(iter.get()))) {
+-            const char* name;
+-            g_variant_get_child(item.get(), 1, "&s", &name);
+-
+-            auto index = chooser->priv->sections.findMatching([&name](const auto& section) {
+-                return !g_strcmp0(name, section.firstEmojiName);
++            auto index = chooser->priv->sections.findMatching([&item](const auto& section) {
++                return sEmojiData->isPartOfSection(item, section);
+             });
+             flowBox = index == notFound ? flowBox : chooser->priv->sections[index].box;
+             auto* child = webkitEmojiChooserAddEmoji(chooser, GTK_FLOW_BOX(flowBox), item.get());
+@@ -587,8 +725,6 @@ static void webkitEmojiChooserConstructed(GObject* object)
+ 
+     webkitEmojiChooserSetupEmojiSections(chooser, GTK_BOX(emojiBox), GTK_BOX(buttonBox));
+ 
+-    gtk_widget_set_state_flags(chooser->priv->sections.first().button, GTK_STATE_FLAG_CHECKED, FALSE);
+-
+     gtk_stack_add_named(GTK_STACK(stack), box, "list");
+     gtk_widget_show(box);
+ 
+@@ -608,6 +744,7 @@ static void webkitEmojiChooserShow(GtkWidget* widget)
+     WebKitEmojiChooser* chooser = WEBKIT_EMOJI_CHOOSER(widget);
+     auto* adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(chooser->priv->swindow));
+     gtk_adjustment_set_value(adjustment, 0);
++    verticalAdjustmentChanged(adjustment, chooser);
+ 
+     gtk_entry_set_text(GTK_ENTRY(chooser->priv->searchEntry), "");
+ }
+@@ -629,6 +766,11 @@ static void webkit_emoji_chooser_class_init(WebKitEmojiChooserClass* klass)
+         nullptr,
+         G_TYPE_NONE, 1,
+         G_TYPE_STRING | G_SIGNAL_TYPE_STATIC_SCOPE);
++
++    if (gtk_check_version(3, 24, 30) == nullptr)
++        sEmojiData = &sNewEmojiData;
++    else
++        sEmojiData = &sOldEmojiData;
+ }
+ 
+ GtkWidget* webkitEmojiChooserNew()
+diff --git a/Source/cmake/FindGTK.cmake b/Source/cmake/FindGTK.cmake
+index abb4b863f43cc55331659a0066f67747d9f8eec0..2158dded30d537ac2d63331223ce4031399abaff 100644
+--- a/Source/cmake/FindGTK.cmake
++++ b/Source/cmake/FindGTK.cmake
+@@ -60,6 +60,8 @@ This will define the following variables in your project:
+   whether GTK 4 was detected
+ ``GTK_3``
+   whether GTK 3 was detected
++``GTK_PREFIX``
++  installation prefix of the GTK libraries.
+ ``GTK_VERSION``
+   the version of GTK.
+ ``GTK_SUPPORTS_BROADWAY``
+@@ -93,6 +95,7 @@ endif ()
+ 
+ find_package(PkgConfig QUIET)
+ pkg_check_modules(GTK IMPORTED_TARGET ${GTK_PC_MODULE})
++pkg_get_variable(GTK_PREFIX ${GTK_PC_MODULE} prefix)
+ 
+ set(GTK_VERSION_OK TRUE)
+ if (GTK_VERSION)
+@@ -147,4 +150,4 @@ foreach (gtk_component ${GTK_FIND_COMPONENTS})
+ endforeach ()
+ 
+ include(FindPackageHandleStandardArgs)
+-FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTK DEFAULT_MSG GTK_VERSION GTK_VERSION_OK)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTK DEFAULT_MSG GTK_VERSION GTK_VERSION_OK GTK_PREFIX)


### PR DESCRIPTION
This updates to the latest webkit release (2.34). We might want to do this in the flatpak platform eventually as well (or instead of here) since the upstream GNOME platform we use (3.38) is no longer maintained now that GNOME 41 is out.

This fixes one security advisory: https://webkitgtk.org/security/WSA-2021-0005.html#CVE-2021-30858, but also includes a lot of web platform updates: https://webkitgtk.org/2021/09/22/webkitgtk2.34.0-released.html

I also pulled in the patch to fix https://github.com/elementary/browser/issues/39. It's not merged upstream yet, but from what I can tell, the remaining work is mostly in ensuring it works correctly on old versions of GTK+ still, which isn't a problem for us. It seems to work fine here. 😀️