### PR TITLE
Update upstream version to 43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.1-${{ matrix.arch }}
       options: --privileged
 
     steps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.1-${{ matrix.arch }}
       options: --privileged
 
     steps:

--- a/data/ephy-non-starred-symbolic.svg
+++ b/data/ephy-non-starred-symbolic.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg6"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path1047-9"
+     d="M 7.9589844 1 A 1.0005882 1.0005882 0 0 0 7.0839844 1.5996094 L 5.5957031 5 L 1.75 5 A 1.0005882 1.0005882 0 0 0 1.0859375 6.7480469 L 4.0800781 9.4003906 L 2.5585938 13.664062 A 1.0005882 1.0005882 0 0 0 4.0214844 14.853516 L 8 12.421875 L 11.978516 14.853516 A 1.0005882 1.0005882 0 0 0 13.441406 13.664062 L 11.919922 9.4003906 L 14.914062 6.7480469 A 1.0005882 1.0005882 0 0 0 14.25 5 L 10.404297 5 L 8.9160156 1.5996094 A 1.0005882 1.0005882 0 0 0 7.9589844 1 z M 8 2 L 9.75 6 L 14.25 6 L 10.75 9.1015625 L 12.5 14 L 8 11.25 L 3.5 14 L 5.25 9.1015625 L 1.75 6 L 6.25 6 L 8 2 z "
+     style="opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+</svg>

--- a/data/ephy-starred-symbolic.svg
+++ b/data/ephy-starred-symbolic.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg6"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path1047-9"
+     class="warning"
+     d="M 7.9589844 1 A 1.0005882 1.0005882 0 0 0 7.0839844 1.5996094 L 5.5957031 5 L 1.75 5 A 1.0005882 1.0005882 0 0 0 1.0859375 6.7480469 L 4.0800781 9.4003906 L 2.5585938 13.664062 A 1.0005882 1.0005882 0 0 0 4.0214844 14.853516 L 8 12.421875 L 11.978516 14.853516 A 1.0005882 1.0005882 0 0 0 13.441406 13.664062 L 11.919922 9.4003906 L 14.914062 6.7480469 A 1.0005882 1.0005882 0 0 0 14.25 5 L 10.404297 5 L 8.9160156 1.5996094 A 1.0005882 1.0005882 0 0 0 7.9589844 1 z M 8 2 L 9.75 6 L 14.25 6 L 10.75 9.1015625 L 12.5 14 L 8 11.25 L 3.5 14 L 5.25 9.1015625 L 1.75 6 L 6.25 6 L 8 2 z "
+     style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     id="path1047"
+     class="warning"
+     d="m 1.7499997,6.000824 3.5,3.1 -1.75,4.9 4.5,-2.75 4.5000003,2.75 -1.75,-4.9 3.5,-3.1 H 9.7499998 l -1.7500001,-4 -1.75,4 z"
+     style="opacity:0.3;vector-effect:none;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;font-variant-east_asian:normal" />
+</svg>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,9 @@
+install_data(
+    'ephy-non-starred-symbolic.svg',
+    install_dir: get_option('datadir') / 'icons' / 'elementary' / 'status' / 'symbolic',
+)
+
+install_data(
+    'ephy-starred-symbolic.svg',
+    install_dir: get_option('datadir') / 'icons' / 'elementary' / 'status' / 'symbolic',
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,4 @@
+project('org.gnome.Epiphany')
+
+subdir('data')
+

--- a/org.gnome.epiphany.yml
+++ b/org.gnome.epiphany.yml
@@ -39,8 +39,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/epiphany.git
-        tag: '42.3'
-        commit: 6cdf86702e747867b2f4b338429733f84f554f80
+        tag: '43.0'
+        commit: e5882e2b1fa040fbe6494ee9808591046a6eafa5
         disable-shallow-clone: true
       - type: patch
         path: navigation-buttons.patch

--- a/org.gnome.epiphany.yml
+++ b/org.gnome.epiphany.yml
@@ -1,6 +1,6 @@
 app-id: org.gnome.Epiphany
 runtime: io.elementary.Platform
-runtime-version: '7'
+runtime-version: '7.1'
 sdk: io.elementary.Sdk
 command: epiphany
 finish-args:

--- a/org.gnome.epiphany.yml
+++ b/org.gnome.epiphany.yml
@@ -44,3 +44,9 @@ modules:
         disable-shallow-clone: true
       - type: patch
         path: navigation-buttons.patch
+
+  - name: customizations
+    buildsystem: meson
+    sources:
+      - type: 'dir'
+        path: '.'


### PR DESCRIPTION
Includes a workaround for https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/1185