### PR TITLE
PostInst: create freedesktop filter if not exists

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -10,10 +10,10 @@ if [ ! -f "$FILE" ]; then
     mkdir -p /etc/flatpak
 
     cat << EOF > /etc/flatpak/freedesktop.filter
-    # Only allow FreeDesktop extensions
-    deny *
-    allow runtime/org.freedesktop.*
-    EOF
+# Only allow FreeDesktop extensions
+deny *
+allow runtime/org.freedesktop.*
+EOF
 fi
 
 flatpak remote-add --if-not-exists --system --filter=/etc/flatpak/freedesktop.filter freedesktop https://flathub.org/repo/flathub.flatpakrepo

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,8 +5,19 @@ set -e
 flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
 flatpak install --system --noninteractive appcenter org.gnome.Epiphany//stable || true
 
+FILE=/etc/flatpak/freedesktop.filter
+if [ ! -f "$FILE" ]; then
+    mkdir -p /etc/flatpak
+
+    cat << EOF > /etc/flatpak/freedesktop.filter
+    # Only allow FreeDesktop extensions
+    deny *
+    allow runtime/org.freedesktop.*
+    EOF
+fi
+
 flatpak remote-add --if-not-exists --system --filter=/etc/flatpak/freedesktop.filter freedesktop https://flathub.org/repo/flathub.flatpakrepo
-flatpak install --system --noninteractive freedesktop org.freedesktop.Platform.GL.default//21.08 || true
+flatpak install --system --noninteractive freedesktop org.freedesktop.Platform.GL.default//22.08 || true
 
 #DEBHELPER#
 


### PR DESCRIPTION
Fixes #70 

It looks like GL isn't being installed on the ISO. My best guess is that the filter file doesn't exist when we're installing, so make sure we check that and create it if we need to

Also bump GL to 22.08 while we're here