### PR TITLE
Bump runtime to 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.1-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.2-${{ matrix.arch }}
       options: --privileged
 
     steps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.1-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.2-${{ matrix.arch }}
       options: --privileged
 
     steps:

--- a/org.gnome.epiphany.json
+++ b/org.gnome.epiphany.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Epiphany",
     "runtime" : "io.elementary.Platform",
-    "runtime-version" : "7.1",
+    "runtime-version" : "7.2",
     "sdk" : "io.elementary.Sdk",
     "command" : "epiphany",
     "finish-args" : [


### PR DESCRIPTION
Fixes #93
Closes https://github.com/orgs/elementary/discussions/201

Since there's some discussion on #83 about regressions, this at least gets us to a newer WebKit that should fix Github rendering etc