### PR TITLE
epiphany: Set version limitation to < 47

### DIFF
--- a/org.gnome.epiphany.json
+++ b/org.gnome.epiphany.json
@@ -31,7 +31,6 @@
                         "type": "gnome",
                         "name": "epiphany",
                         "versions": {
-                            /* TODO: Remove once libadwaita >= 1.6.alpha is available on our Flatpak platform */
                             "<": "47"
                         }
                     }

--- a/org.gnome.epiphany.json
+++ b/org.gnome.epiphany.json
@@ -29,7 +29,11 @@
                     "sha256": "a9e1ad206449117fc5ebe4d0177c1d7a2ff503d6b55019072a068ff2ab278656",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "epiphany"
+                        "name": "epiphany",
+                        "versions": {
+                            /* TODO: Remove once libadwaita >= 1.6.alpha is available on our Flatpak platform */
+                            "<": "47"
+                        }
                     }
                 },
                 {


### PR DESCRIPTION
Until our libadwaita gets newer than  1.6.alpha, let's get updates for 46.x (see https://github.com/elementary/browser/pull/146#issuecomment-2355923282).

Confirmed locally that external-data-checker detects epiphany-46.4 instead of epiphany-47.0:

```
user@VirtualBox-d26a3e7f:~/work/browser$ flatpak run org.flathub.flatpak-external-data-checker org.gnome.epiphany.json
INFO    src.manifest: Checking 1 external data items
INFO    src.manifest: Started check [1/1] archive epiphany/epiphany-46.3.tar.xz (from org.gnome.epiphany.json)
INFO    src.lib.externaldata: Source epiphany-46.3.tar.xz: got new version 46.4
INFO    src.manifest: Finished check [1/1] archive epiphany/epiphany-46.3.tar.xz (from org.gnome.epiphany.json)
OUTDATED: epiphany-46.3.tar.xz
 Has a new version:
  URL:       https://download.gnome.org/sources/epiphany/46/epiphany-46.4.tar.xz
  MD5:       None
  SHA1:      None
  SHA256:    ae34c388830fdbee57c04e32b0ccd97608d76055b99d940020ed57354a3f6d87
  SHA512:    None
  Size:      None
  Version:   46.4
  Timestamp: None

INFO    src.main: Check finished with 0 error(s)
user@VirtualBox-d26a3e7f:~/work/browser$
```